### PR TITLE
Add center point pixel normalization

### DIFF
--- a/configs/data/all_transforms/NormalizeFromCenter.yaml
+++ b/configs/data/all_transforms/NormalizeFromCenter.yaml
@@ -1,0 +1,5 @@
+NormalizeFromCenter:
+  _target_: src.data.components.augmentations.NormalizeFromCenter
+  im_w: 1280
+  im_h: 720
+  feat_version: 3

--- a/configs/data/all_transforms/default.yaml
+++ b/configs/data/all_transforms/default.yaml
@@ -1,6 +1,7 @@
 defaults:
   - MoveCenterPts
   - NormalizePixelPts
+  - NormalizeFromCenter
   - _self_
 
 train_order: ['MoveCenterPts', 'NormalizePixelPts']

--- a/src/data/components/PTG_dataset.py
+++ b/src/data/components/PTG_dataset.py
@@ -56,6 +56,12 @@ class PTG_Dataset(torch.utils.data.Dataset):
         self.target_frames = np.concatenate(target_frames_list, axis=0, dtype=int, casting='unsafe')
         self.mask_frames = np.concatenate(mask_frames_list, axis=0, dtype=int, casting='unsafe')
 
+        # Transforms/Augmentations
+        if self.transform is not None:
+            self.feature_frames = self.transform(self.feature_frames)
+        if self.target_transform is not None:
+            self.target_frames = self.target_transform(self.target_frames)
+
         self.norm_stats['mean'] = self.feature_frames.mean(axis=0)
         self.norm_stats['std'] = self.feature_frames.std(axis=0)
         self.norm_stats['max'] = self.feature_frames.max(axis=0)
@@ -90,11 +96,5 @@ class PTG_Dataset(torch.utils.data.Dataset):
         features = self.feature_frames[idx:idx+self.window_size,:]
         target = self.target_frames[idx:idx+self.window_size]
         mask = self.mask_frames[idx:idx+self.window_size]
-
-        # Transforms/Augmentations
-        if self.transform is not None:
-            features = self.transform(features)
-        if self.target_transform is not None:
-            target = self.target_transform(target)
         
         return features, target, mask

--- a/src/data/components/augmentations.py
+++ b/src/data/components/augmentations.py
@@ -223,11 +223,71 @@ class NormalizePixelPts(torch.nn.Module):
             window[:, hands_dist_idx] = window[:, hands_dist_idx] / self.im_w
             window[:, hands_dist_idx + 1] = window[:, hands_dist_idx + 1] / self.im_h
 
+        elif self.feat_version == 3:
+            pass
+
+        else:
+            NotImplementedError(f"Unhandled version '{self.feat_version}'")
+
+        
+        return window
+
+    def __repr__(self) -> str:
+        detail = f"(im_w={self.im_w}, im_h={self.im_h}, num_obj_classes={self.num_obj_classes}, feat_version={self.feat_version})"
+        return f"{self.__class__.__name__}{detail}"
+
+class NormalizeFromCenter(torch.nn.Module):
+    """Normalize the distances from -1 to 1 with respect to the image center
+    
+    Missing objects will be set to (2, 2)
+    """
+
+    def __init__(self, im_w, im_h, feat_version):
+        """
+        :param w: Width of the frames
+        :param h: Height of the frames
+        :param feat_version: Algorithm version used to generate the input features
+        """
+        super().__init__()
+
+        self.im_w = im_w
+        self.half_w = im_w / 2
+        self.im_h = im_h
+        self.half_h = im_h / 2
+
+        self.feat_version = feat_version
+
+    def forward(self, window):
+        if self.feat_version == 1:
+            pass
+
+        elif self.feat_version == 2:
+            pass
+
+        elif self.feat_version == 3:
+            # Right and left hand distances
+            start_idx = 3; end_idx = 7
+            window[:, start_idx:end_idx:2] = (
+                window[:, start_idx:end_idx:2] / self.half_w
+            )
+            
+            window[:, start_idx + 1 : end_idx : 2] = (
+                window[:, start_idx + 1 : end_idx : 2] / self.half_h
+            )
+
+            # Object distances
+            start_idx = 10
+            while start_idx < window.shape[1]:
+                window[:, start_idx] = window[:, start_idx] / self.half_w
+                window[:, start_idx + 1] = window[:, start_idx + 1] / self.half_h
+                start_idx += 5
+
         else:
             NotImplementedError(f"Unhandled version '{self.feat_version}'")
 
         return window
 
     def __repr__(self) -> str:
-        detail = f"(im_w={self.im_w}, im_h={self.im_h}, num_obj_classes={self.num_obj_classes}, feat_version={self.feat_version})"
+        detail = f"(im_w={self.im_w}, im_h={self.im_h}, feat_version={self.feat_version})"
         return f"{self.__class__.__name__}{detail}"
+   


### PR DESCRIPTION
## What does this PR do?

Normalize the distance from the center of the image to (-1, 1). Missing objects will end up being set to 2. 

Fix bug where the transformations were applied to data points multiple times

Ex:
```bash
w[0:30] * transform
w[1:31] * transform # transform is applied to w[1:30] twice
# so on....
```

## Before submitting

- [ ] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
