### PR TITLE
Fix pose generation to COCO method to correctly convert to xywh boxes

### DIFF
--- a/tcn_hpl/data/utils/pose_generation/generate_pose_data.py
+++ b/tcn_hpl/data/utils/pose_generation/generate_pose_data.py
@@ -324,6 +324,11 @@ class PosesGenerator(object):
             img = read_image(img_path, format="BGR")
             boxes, scores, classes, keypoints_list = self.predict_single(img)
 
+            # boxes is output in xyxy (ltrb), but the COCO format wants xywh
+            # format.
+            boxes[:, 2] -= boxes[:, 0]
+            boxes[:, 3] -= boxes[:, 1]
+
             # We will need non-numpy data types to insert into the structure to
             # follow JSON compliance.
             boxes_list = boxes.tolist()


### PR DESCRIPTION
## What does this PR do?

For COCO file generation, fix output of bbox to `xywh` format instead of the prediction default of `ltrb`.

Fixes #\<issue_number>

## Before submitting

- [ ] Did you make sure **title is self-explanatory** and **the description concisely explains the PR**?
- [ ] Did you make sure your **PR does only one thing**, instead of bundling different changes together?
- [ ] Did you list all the **breaking changes** introduced by this pull request?
- [ ] Did you **test your PR locally** with `pytest` command?
- [ ] Did you **run pre-commit hooks** with `pre-commit run -a` command?

## Did you have fun?

Make sure you had fun coding 🙃
