### PR TITLE
Fix validation set loading during fit stage

### DIFF
--- a/tcn_hpl/data/ptg_datamodule.py
+++ b/tcn_hpl/data/ptg_datamodule.py
@@ -177,7 +177,7 @@ class PTGDataModule(LightningDataModule):
                 kwcoco.CocoDataset(self.hparams.coco_train_poses),
                 self.hparams.target_framerate,
             )
-        if stage == "validate" and not self.data_val:
+        if (stage == "validate" or stage == "fit") and not self.data_val:
             self.data_val.load_data_offline(
                 kwcoco.CocoDataset(self.hparams.coco_validation_activities),
                 kwcoco.CocoDataset(self.hparams.coco_validation_objects),


### PR DESCRIPTION
## What does this PR do?
Oops. Fix dataset loading when the mode is "fit", which does want the validation dataset for its "sanity check" pass.