### PR TITLE
Fix how tcn test considers total num classes automatically

### DIFF
--- a/tcn_hpl/data/tcn_dataset.py
+++ b/tcn_hpl/data/tcn_dataset.py
@@ -521,7 +521,7 @@ def test_dataset_for_input(
     # TODO: Some method of configuring which vectorizer to use.
     from tcn_hpl.data.vectorize.locs_and_confs import LocsAndConfs
 
-    num_object_classes = len(dets_coco.cats)
+    num_object_classes = max(dets_coco.cats) + 1
     vectorize = LocsAndConfs(
         top_k=1,
         num_classes=num_object_classes,


### PR DESCRIPTION
Some detection inputs have "missing" categories due to their being skipped during detection inference. This creates a discrepancy between quantity of listed categories vs category IDs that can be listed. Instead consider the max category ID + 1, on the assumption that category IDs start at 0, which is a strong assumption due to considering category IDs as the index of prediction outputs to which that category applies.